### PR TITLE
refactor: centralize error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,9 +16,9 @@ app.use(express.json()); // supaya bisa baca JSON body
 // Route utama
 app.use('/', routes);
 
-// 404 handler sederhana
+// 404 handler sederhana -> lempar ke errorHandler
 app.use((req, res, next) => {
-  res.status(404).json({ message: 'Not Found' });
+  next({ name: 'Data not found' });
 });
 
 // Error handler global sederhana: selalu balikan { message }

--- a/controllers/aiController.js
+++ b/controllers/aiController.js
@@ -8,7 +8,8 @@ module.exports = {
       // ambil input sederhana
       const { resume_text = '', job_description = '', tone = 'profesional', lang = 'id' } = req.body;
       if (!resume_text || !job_description) {
-        return res.status(400).json({ message: 'resume_text and job_description are required' });
+        // lempar error agar ditangani errorHandler
+        throw { status: 400, message: 'resume_text and job_description are required' };
       }
 
       // Siapkan prompt yang mudah dimengerti

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -8,7 +8,7 @@ module.exports = {
   async googleLogin(req, res, next) {
     try {
       const { idToken } = req.body;
-      if (!idToken) return res.status(400).json({ message: 'idToken is required' });
+      if (!idToken) throw { status: 400, message: 'idToken is required' };
 
       // Verifikasi token ke Google
       const { name, email, googleId } = await verifyGoogleIdToken(idToken);

--- a/controllers/jobsController.js
+++ b/controllers/jobsController.js
@@ -96,7 +96,7 @@ module.exports = {
   async searchJobs(req, res, next) {
     try {
       const { q = '', location = '', next_page_token = '' } = req.query;
-      if (!q.trim()) return res.status(400).json({ message: 'Query q is required' });
+      if (!q.trim()) throw { status: 400, message: 'Query q is required' };
 
       const raw = await searchJobs({ q, location, next_page_token });
 
@@ -117,7 +117,7 @@ module.exports = {
       if (err.response) {
         const s = err.response.status || 500;
         const m = err.response.data?.error || err.response.data?.message || 'Upstream error';
-        return res.status(s).json({ message: `SerpAPI: ${m}` });
+        return next({ status: s, message: `SerpAPI: ${m}` });
       }
       next(err);
     }

--- a/controllers/resumesController.js
+++ b/controllers/resumesController.js
@@ -22,7 +22,7 @@ module.exports = {
       const userId = req.user.id;
       const { title = '', contentText = '' } = req.body;
 
-      if (!title) return res.status(400).json({ message: 'title is required' });
+      if (!title) throw { status: 400, message: 'title is required' };
 
       const created = await Resume.create({ userId, title, contentText });
       res.status(201).json({ message: 'Created', data: created });
@@ -39,7 +39,7 @@ module.exports = {
       const { title, contentText } = req.body;
 
       const found = await Resume.findOne({ where: { id, userId } });
-      if (!found) return res.status(404).json({ message: 'Not Found' });
+      if (!found) throw { name: 'Data not found' };
 
       if (title !== undefined) found.title = title;
       if (contentText !== undefined) found.contentText = contentText;
@@ -58,7 +58,7 @@ module.exports = {
       const { id } = req.params;
 
       const found = await Resume.findOne({ where: { id, userId } });
-      if (!found) return res.status(404).json({ message: 'Not Found' });
+      if (!found) throw { name: 'Data not found' };
 
       await found.destroy();
       res.json({ message: 'Deleted' });

--- a/controllers/savedJobsController.js
+++ b/controllers/savedJobsController.js
@@ -23,8 +23,8 @@ module.exports = {
       const userId = req.user.id;
       const { jobExternalId = '', source = 'google', jobPayload = {} } = req.body;
 
-      if (!jobExternalId) return res.status(400).json({ message: 'jobExternalId is required' });
-      if (!source) return res.status(400).json({ message: 'source is required' });
+      if (!jobExternalId) throw { status: 400, message: 'jobExternalId is required' };
+      if (!source) throw { status: 400, message: 'source is required' };
 
       const created = await SavedJob.create({
         userId,
@@ -37,7 +37,6 @@ module.exports = {
     } catch (err) {
       if (err instanceof UniqueConstraintError) {
         // Jika duplikat (unik pada userId + jobExternalId + source)
-        err.status = 409;
         err.message = 'Already saved';
       }
       next(err);
@@ -51,7 +50,7 @@ module.exports = {
       const { id } = req.params;
 
       const found = await SavedJob.findOne({ where: { id, userId } });
-      if (!found) return res.status(404).json({ message: 'Not Found' });
+      if (!found) throw { name: 'Data not found' };
 
       await found.destroy();
       res.json({ message: 'Deleted' });

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -9,7 +9,8 @@ module.exports = function auth(req, res, next) {
     const token = parts.length === 2 && parts[0] === 'Bearer' ? parts[1] : null;
 
     if (!token) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      // jika tidak ada token lempar error khusus
+      throw { name: 'Unauthenticated' };
     }
 
     const payload = jwt.verify(token, process.env.JWT_SECRET);
@@ -17,6 +18,7 @@ module.exports = function auth(req, res, next) {
     req.user = { id: payload.id, email: payload.email, name: payload.name };
     next();
   } catch (err) {
-    return res.status(401).json({ message: 'Invalid token' });
+    // lempar error ke errorHandler
+    next(err);
   }
 };

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,7 +1,47 @@
-// Global error handler simple: selalu balikan JSON { message }
+// Global error handler
+// Seluruh error dari controller / middleware akan berakhir di sini
+// dan dibalas dalam format JSON { message }
 module.exports = (err, req, res, next) => {
-  console.error(err); // untuk debugging di server
-  const status = err.status || 500;
-  const message = err.message || 'Internal Server Error';
+  console.error(err); // log dulu untuk debugging di server
+
+  let status = 500; // default 500
+  let message = 'Internal Server Error';
+
+  // Error bawaan Sequelize ketika validasi atau unik gagal
+  if (err.name === 'SequelizeValidationError' || err.name === 'SequelizeUniqueConstraintError') {
+    status = 400;
+    // ambil pesan pertama dari array errors jika ada
+    message = err.errors?.[0]?.message || message;
+
+    // Error JWT dari jsonwebtoken.verify
+  } else if (err.name === 'JsonWebTokenError') {
+    status = 401;
+    message = 'Invalid token';
+
+    // Error custom dari middleware auth ketika tidak ada token
+  } else if (err.name === 'Unauthenticated') {
+    status = 401;
+    message = 'Unauthenticated';
+
+    // Error ketika user tidak punya akses
+  } else if (err.name === 'Forbidden') {
+    status = 403;
+    message = 'Forbidden';
+
+    // Ketika data yang diminta tidak ditemukan
+  } else if (err.name === 'Data not found') {
+    status = 404;
+    message = 'Data not found';
+
+    // Jika ada err.status manual dari controller
+  } else if (err.status) {
+    status = err.status;
+    message = err.message || message;
+
+    // Fallback: gunakan message bawaan error jika ada
+  } else if (err.message) {
+    message = err.message;
+  }
+
   res.status(status).json({ message });
 };


### PR DESCRIPTION
## Summary
- centralize API error handling with a middleware mapping common errors to status codes
- propagate controller and auth errors via throw/next instead of direct responses
- route unmatched paths to error handler for consistent 404 responses

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a683112380832b82320128e3407f23