### PR TITLE
Handle unauthenticated saved jobs and avoid empty job search

### DIFF
--- a/client/src/features/saved/savedSlice.js
+++ b/client/src/features/saved/savedSlice.js
@@ -15,7 +15,7 @@ export const saveJob = createAsyncThunk('saved/add', async (payload, { rejectWit
     const { data } = await http.post('/saved', payload)
     return { item: data?.data || data }
   } catch (err) {
-    return rejectWithValue(err.response.data.message || err.message)
+    return rejectWithValue(err?.response?.data?.message || err.message)
   }
 })
 

--- a/client/src/pages/Jobs.jsx
+++ b/client/src/pages/Jobs.jsx
@@ -8,8 +8,11 @@ export default function Jobs() {
   const dispatch = useDispatch()
   const { list, status, error, q, location } = useSelector(s=>s.jobs)
 
-  useEffect(()=>{ 
-    if (list.length === 0) dispatch(fetchJobs({ q: '', location: '', page: 1 }))
+  // Hindari fetch otomatis ketika q kosong yang menyebabkan 400 dari backend
+  useEffect(()=>{
+    if (list.length === 0 && q.trim()) {
+      dispatch(fetchJobs({ q, location, page: 1 }))
+    }
   }, []) // eslint-disable-line
 
   const handleSearch = (e) => {

--- a/server/controllers/savedJobsController.js
+++ b/server/controllers/savedJobsController.js
@@ -20,7 +20,8 @@ module.exports = {
   // POST /saved -> simpan payload job ke JSONB
   async saveJob(req, res, next) {
     try {
-      const userId = req.user.id;
+      const userId = req.user?.id;
+      if (!userId) throw { name: 'Unauthenticated' };
       const { jobExternalId = '', source = 'google', jobPayload = {} } = req.body;
 
       if (!jobExternalId) throw { status: 400, message: 'jobExternalId is required' };
@@ -46,7 +47,8 @@ module.exports = {
   // DELETE /saved/:id
   async deleteSavedJob(req, res, next) {
     try {
-      const userId = req.user.id;
+      const userId = req.user?.id;
+      if (!userId) throw { name: 'Unauthenticated' };
       const { id } = req.params;
 
       const found = await SavedJob.findOne({ where: { id, userId } });


### PR DESCRIPTION
## Summary
- Skip initial empty job search request to avoid 400 errors
- Guard saved job endpoints against missing authentication
- Harden client error handling for saving jobs

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (client) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a70c148d8c832b80f31c4ff365696a