### PR TITLE
Make auth middleware case-insensitive for Bearer token

### DIFF
--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -6,7 +6,11 @@ module.exports = function auth(req, res, next) {
     // Ambil token dari header: Authorization: Bearer <token>
     const authHeader = req.headers.authorization || '';
     const parts = authHeader.split(' ');
-    const token = parts.length === 2 && parts[0] === 'Bearer' ? parts[1] : null;
+    // allow case-insensitive "Bearer" scheme to support different clients
+    const token =
+      parts.length === 2 && parts[0].toLowerCase() === 'bearer'
+        ? parts[1]
+        : null;
 
     if (!token) {
       // jika tidak ada token lempar error khusus


### PR DESCRIPTION
## Summary
- make JWT auth middleware accept lower/upper case `Bearer`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a7146205d8832b8f73759a517054d3