### PR TITLE
Fix saved job handling and prevent duplicate saves

### DIFF
--- a/client/src/pages/JobsPage.jsx
+++ b/client/src/pages/JobsPage.jsx
@@ -81,6 +81,7 @@ import LoadingSkeleton from '@/components/ui/LoadingSkeleton'
 export default function JobsPage(){
   const dispatch = useDispatch()
   const { q, location, results, status, error } = useSelector(s=>s.jobs)
+  const savedList = useSelector(s=>s.saved.list)
 
   const handleSearch = ()=>{
     if (!q || !q.trim()) return
@@ -147,19 +148,28 @@ export default function JobsPage(){
         <EmptyState title="Tidak ada hasil" description="Coba ubah kata kunci atau lokasi." />
       ) : (
         <div className="grid gap-3">
-          {results.map(job => (
-            <div key={job.externalId} className="rounded-xl border bg-white p-4">
-              <div className="flex items-start justify-between gap-2">
-                <div>
-                  <h3 className="text-lg font-semibold">{job.title}</h3>
-                  <p className="text-sm text-zinc-600">{job.company} • {job.location || 'Lokasi tidak tersedia'}</p>
-                </div>
-                <div className="flex gap-2">
-                  <button onClick={()=>handleSave(job)} className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm text-white">Save</button>
+          {results.map(job => {
+            const alreadySaved = savedList.some(j=> j.jobExternalId === job.externalId)
+            return (
+              <div key={job.externalId} className="rounded-xl border bg-white p-4">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <h3 className="text-lg font-semibold">{job.title}</h3>
+                    <p className="text-sm text-zinc-600">{job.company} • {job.location || 'Lokasi tidak tersedia'}</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      disabled={alreadySaved}
+                      onClick={()=>handleSave(job)}
+                      className={`rounded-lg px-3 py-1.5 text-sm text-white ${alreadySaved ? 'bg-zinc-400 cursor-not-allowed' : 'bg-blue-600'}`}
+                    >
+                      {alreadySaved ? 'Saved' : 'Save'}
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </section>

--- a/client/src/slices/savedJobsSlice.js
+++ b/client/src/slices/savedJobsSlice.js
@@ -22,6 +22,11 @@ const savedJobsSlice = createSlice({
     b.addCase(fetchSavedJobs.pending, (s)=>{ s.status='loading'; s.error=null })
      .addCase(fetchSavedJobs.fulfilled, (s,a)=>{ s.status='succeeded'; s.list=a.payload?.data || [] })
      .addCase(fetchSavedJobs.rejected, (s,a)=>{ s.status='failed'; s.error=a.error?.message || 'Gagal mengambil saved jobs' })
+     .addCase(saveJob.fulfilled, (s,a)=>{
+       const item = a.payload?.data
+       if (item) s.list.unshift(item)
+     })
+     .addCase(saveJob.rejected, (s,a)=>{ s.error = a.error?.message || 'Gagal menyimpan job' })
      .addCase(deleteSavedJob.fulfilled, (s,a)=>{ s.list = s.list.filter(j=> j.id !== a.payload.id) })
   }
 })


### PR DESCRIPTION
## Summary
- track newly saved jobs in Redux state and capture save errors
- disable Save button for jobs already stored

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a7b0482698832b84903592510d847e